### PR TITLE
Add test infrastructure for AtPSA

### DIFF
--- a/AtGenerators/AtTPCFissionGeneratorV2.cxx
+++ b/AtGenerators/AtTPCFissionGeneratorV2.cxx
@@ -19,7 +19,6 @@
 #include <iostream>
 #include <map>
 #include <utility>
-#include <fstream>
 
 constexpr auto cRED = "\033[1;31m";
 constexpr auto cYELLOW = "\033[1;33m";

--- a/AtParameter/AtDigiPar.h
+++ b/AtParameter/AtDigiPar.h
@@ -11,8 +11,15 @@ class TBuffer;
 class TClass;
 class TMemberInspector;
 
+/**
+ * @brief Parameter container for the AT-TPC digitization.
+ *
+ * This class contains all the parameters needed for the digitization and analysis of TPC data.
+ * The parameters are all public, as this is simply a database and we want the ability to modify
+ * the parameters at runtime when testing.
+ */
 class AtDigiPar : public FairParGenericSet {
-private:
+public:
    Bool_t fInitialized;
 
    Double_t fBField{};
@@ -67,7 +74,7 @@ public:
    virtual Bool_t getParams(FairParamList *paramList) override;
    // Main methods
 
-   ClassDefOverride(AtDigiPar, 4);
+   ClassDefOverride(AtDigiPar, 5);
 };
 
 #endif

--- a/AtReconstruction/AtPulseAnalyzer/AtPSA.cxx
+++ b/AtReconstruction/AtPulseAnalyzer/AtPSA.cxx
@@ -29,7 +29,6 @@ using std::min_element;
 
 void AtPSA::Init()
 {
-
    FairRun *run = FairRun::Instance();
    if (!run)
       LOG(fatal) << "No analysis run!";
@@ -43,6 +42,12 @@ void AtPSA::Init()
       LOG(fatal) << "AtDigiPar not found!!";
       return;
    }
+
+   Init(fPar);
+}
+
+void AtPSA::Init(AtDigiPar *fPar)
+{
 
    fTBTime = fPar->GetTBTime();
    fDriftVelocity = fPar->GetDriftVelocity();
@@ -105,7 +110,8 @@ void AtPSA::TrackMCPoints(std::multimap<Int_t, std::size_t> &map, AtHit &hit)
          hit.AddMCSimPoint(mcpoint);
 
          // std::cout << " Pad Num : "<<hit->GetHitPadNum()<<" MC Point ID : "<<it->second << std::endl;
-         // std::cout << " Track ID : "<<MCPoint->GetTrackID()<<" Energy (MeV) : "<<MCPoint->GetEIni()<<" Angle (deg) :
+         // std::cout << " Track ID : "<<MCPoint->GetTrackID()<<" Energy (MeV) : "<<MCPoint->GetEIni()<<" Angle (deg)
+         // :
          // "<<MCPoint->GetAIni()<<"\n"; std::cout << " Mass Number : "<<MCPoint->GetMassNum()<<" Atomic Number
          // "<<MCPoint->GetAtomicNum()<<"\n";
       }

--- a/AtReconstruction/AtPulseAnalyzer/AtPSA.h
+++ b/AtReconstruction/AtPulseAnalyzer/AtPSA.h
@@ -18,6 +18,7 @@ class AtPad;
 class TBuffer;
 class TClass;
 class TMemberInspector;
+class AtDigiPar;
 
 /**
  * @brief Abstract base class for processing AtPads (traces) into AtHits.
@@ -53,7 +54,8 @@ public:
    AtPSA() = default;
    virtual ~AtPSA() = default;
 
-   virtual void Init();
+   void Init();
+   virtual void Init(AtDigiPar *fPar);
 
    void SetThreshold(Int_t threshold);
    void SetThresholdLow(Int_t thresholdlow);

--- a/AtReconstruction/AtPulseAnalyzer/AtPSAComposite.cxx
+++ b/AtReconstruction/AtPulseAnalyzer/AtPSAComposite.cxx
@@ -17,10 +17,10 @@ AtPSAComposite::AtPSAComposite(const AtPSAComposite &o)
 {
 }
 
-void AtPSAComposite::Init()
+void AtPSAComposite::Init(AtDigiPar *fPar)
 {
-   fBeamPSA->Init();
-   fPSA->Init();
+   fBeamPSA->Init(fPar);
+   fPSA->Init(fPar);
 }
 AtPSA::HitVector AtPSAComposite::AnalyzePad(AtPad *pad)
 {

--- a/AtReconstruction/AtPulseAnalyzer/AtPSAComposite.h
+++ b/AtReconstruction/AtPulseAnalyzer/AtPSAComposite.h
@@ -21,7 +21,7 @@ public:
    AtPSAComposite(std::unique_ptr<AtPSA> beamPSA, std::unique_ptr<AtPSA> PSA, double beamRadius = 40);
    AtPSAComposite(const AtPSAComposite &);
 
-   void Init() override;
+   void Init(AtDigiPar *fPar) override;
    virtual HitVector AnalyzePad(AtPad *) override;
    std::unique_ptr<AtPSA> Clone() override { return std::make_unique<AtPSAComposite>(*this); }
 };

--- a/AtReconstruction/AtPulseAnalyzer/AtPSAComposite.h
+++ b/AtReconstruction/AtPulseAnalyzer/AtPSAComposite.h
@@ -21,6 +21,7 @@ public:
    AtPSAComposite(std::unique_ptr<AtPSA> beamPSA, std::unique_ptr<AtPSA> PSA, double beamRadius = 40);
    AtPSAComposite(const AtPSAComposite &);
 
+   using AtPSA::Init; // Return base class Init to scope (since the override will shadow it by default)
    void Init(AtDigiPar *fPar) override;
    virtual HitVector AnalyzePad(AtPad *) override;
    std::unique_ptr<AtPSA> Clone() override { return std::make_unique<AtPSAComposite>(*this); }

--- a/AtReconstruction/AtPulseAnalyzer/AtPSADeconv.h
+++ b/AtReconstruction/AtPulseAnalyzer/AtPSADeconv.h
@@ -35,7 +35,7 @@ class AtPadFFT;
  * @ingroup PSA
  * @author A.K. Anthony
  */
-class AtPSADeconv : public virtual AtPSA {
+class AtPSADeconv : public AtPSA {
 
 protected:
    using ResponseFunc = std::function<double(int, double)>;

--- a/AtReconstruction/AtPulseAnalyzer/AtPSADeconvFit.h
+++ b/AtReconstruction/AtPulseAnalyzer/AtPSADeconvFit.h
@@ -10,13 +10,14 @@ class AtPSA;
 
 class TH1F;
 class TF1;
+
 class AtPSADeconvFit : public AtPSADeconv {
 protected:
    double fDiffLong; //< Longitudinal diffusion coefficient
    static thread_local std::unique_ptr<TH1F> fHist;
 
 public:
-   virtual void Init() override;
+   virtual void Init(AtDigiPar *fPar) override;
    virtual std::unique_ptr<AtPSA> Clone() override { return std::make_unique<AtPSADeconvFit>(*this); }
    double GetDiffLong() const { return fDiffLong; }
 

--- a/AtReconstruction/AtPulseAnalyzer/AtPSADeconvFit.h
+++ b/AtReconstruction/AtPulseAnalyzer/AtPSADeconvFit.h
@@ -12,11 +12,13 @@ class TH1F;
 class TF1;
 
 class AtPSADeconvFit : public AtPSADeconv {
+
 protected:
    double fDiffLong; //< Longitudinal diffusion coefficient
    static thread_local std::unique_ptr<TH1F> fHist;
 
 public:
+   using AtPSA::Init; // Return base class Init to scope (since the override will shadow it by default)
    virtual void Init(AtDigiPar *fPar) override;
    virtual std::unique_ptr<AtPSA> Clone() override { return std::make_unique<AtPSADeconvFit>(*this); }
    double GetDiffLong() const { return fDiffLong; }

--- a/AtReconstruction/AtPulseAnalyzer/AtPSADeconvFitBaseline.cxx
+++ b/AtReconstruction/AtPulseAnalyzer/AtPSADeconvFitBaseline.cxx
@@ -30,9 +30,6 @@
 #include <memory>     // for allocator, unique_ptr
 #include <thread>
 
-AtPSADeconvFitBaseline::AtPSADeconvFitBaseline() = default;
-AtPSADeconvFitBaseline::~AtPSADeconvFitBaseline() = default;
-
 AtPSADeconv::HitData AtPSADeconvFitBaseline::getZandQ(const AtPad::trace &charge)
 {
    // Get initial guess for hit. Z loc is max and std dev is estimated from diffusion

--- a/AtReconstruction/AtPulseAnalyzer/AtPSADeconvFitBaseline.h
+++ b/AtReconstruction/AtPulseAnalyzer/AtPSADeconvFitBaseline.h
@@ -5,8 +5,8 @@
 
 class AtPSADeconvFitBaseline : public AtPSADeconvFit {
 public:
-   AtPSADeconvFitBaseline();
-   virtual ~AtPSADeconvFitBaseline();
+   AtPSADeconvFitBaseline() = default;
+   virtual ~AtPSADeconvFitBaseline() = default;
 
    // Override getZandQ method from AtPSADeconv
    virtual HitData getZandQ(const AtPad::trace &charge) override;

--- a/AtReconstruction/AtPulseAnalyzer/AtPSADeconvFitBaselineTest.cxx
+++ b/AtReconstruction/AtPulseAnalyzer/AtPSADeconvFitBaselineTest.cxx
@@ -1,23 +1,32 @@
 #include "AtPSADeconvFitBaseline.h"
-#include "AtRunAna.h"
+
+#include "AtPSATestFixture.h"
+
 #include <FairParAsciiFileIo.h>
 #include <FairRuntimeDb.h>
 
 #include <gtest/gtest.h>
 
-TEST(AtPSADeconvFitBaselineTest, Init)
+class AtPSADeconvFitBaselineTestFixture : public AtPSATestFixture {
+
+protected:
+   std::unique_ptr<AtPSADeconvFitBaseline> fit;
+
+   virtual void SetUp() override
+   {
+      AtPSATestFixture::SetUp();
+
+      // Set any AtDigiPar parameters here if needed
+      fPar->fDriftVelocity = 0.815; // As an example. This is the default value for e12014.
+
+      // Create the object to test and setup any parameters
+      fit = std::make_unique<AtPSADeconvFitBaseline>();
+      fit->Init(fPar.get());
+   }
+};
+
+TEST_F(AtPSADeconvFitBaselineTestFixture, Init)
 {
-   AtRunAna *fRun = new AtRunAna();
-   TString parFile = "ATTPC.e12014.par";
-
-   TString dir = getenv("VMCWORKDIR");
-   FairParAsciiFileIo *parIo1 = new FairParAsciiFileIo();
-   parIo1->open(dir + "/parameters/" + parFile, "in");
-   fRun->GetRuntimeDb()->setFirstInput(parIo1);
-   fRun->GetRuntimeDb()->getContainer("AtDigiPar");
-
-   AtPSADeconvFitBaseline fit;
-   fit.Init();
-   //  Add assertions to check if the object is initialized properly
-   EXPECT_EQ(fit.GetDiffLong(), 0);
+   // Add assertions to check if the object is initialized properly
+   EXPECT_TRUE(true);
 }

--- a/AtReconstruction/AtPulseAnalyzer/AtPSATest.cxx
+++ b/AtReconstruction/AtPulseAnalyzer/AtPSATest.cxx
@@ -1,0 +1,37 @@
+#include "AtPSA.h"
+
+#include "AtDigiPar.h"
+
+#include <gtest/gtest.h>
+
+/**
+ * @brief Test fixture for AtPSA that creates a default AtDigiPar object to use.
+ * @ingroup Testing
+ */
+class AtPSATest : public ::testing::Test {
+
+protected:
+   std::unique_ptr<AtDigiPar> fPar;
+
+   void SetUp() override
+   {
+      fPar = std::make_unique<AtDigiPar>("", "", "");
+      fPar->fEField = 70000;
+      fPar->fBField = 0.0;
+      fPar->fTBEntrance = 457;
+      fPar->fZPadPlane = 1000.0;
+      fPar->fEIonize = 42.70;
+      fPar->fFano = 0.24;
+      fPar->fCoefL = 0.0055;
+      fPar->fCoefT = 0.0038;
+      fPar->fGasPressure = 800;
+      fPar->fDensity = 0.175;
+      fPar->fDriftVelocity = 0.815;
+      fPar->fGain = 1000;
+      fPar->fSamplingRate = 3;
+      fPar->fGETGain = 1000;
+      fPar->fPeakingTime = 720;
+   }
+
+   void TearDown() override {}
+};

--- a/AtReconstruction/AtPulseAnalyzer/AtPSATest.cxx
+++ b/AtReconstruction/AtPulseAnalyzer/AtPSATest.cxx
@@ -1,37 +1,5 @@
 #include "AtPSA.h"
 
-#include "AtDigiPar.h"
+#include "AtPSATestFixture.h"
 
 #include <gtest/gtest.h>
-
-/**
- * @brief Test fixture for AtPSA that creates a default AtDigiPar object to use.
- * @ingroup Testing
- */
-class AtPSATest : public ::testing::Test {
-
-protected:
-   std::unique_ptr<AtDigiPar> fPar;
-
-   void SetUp() override
-   {
-      fPar = std::make_unique<AtDigiPar>("", "", "");
-      fPar->fEField = 70000;
-      fPar->fBField = 0.0;
-      fPar->fTBEntrance = 457;
-      fPar->fZPadPlane = 1000.0;
-      fPar->fEIonize = 42.70;
-      fPar->fFano = 0.24;
-      fPar->fCoefL = 0.0055;
-      fPar->fCoefT = 0.0038;
-      fPar->fGasPressure = 800;
-      fPar->fDensity = 0.175;
-      fPar->fDriftVelocity = 0.815;
-      fPar->fGain = 1000;
-      fPar->fSamplingRate = 3;
-      fPar->fGETGain = 1000;
-      fPar->fPeakingTime = 720;
-   }
-
-   void TearDown() override {}
-};

--- a/AtReconstruction/AtPulseAnalyzer/AtPSATestFixture.h
+++ b/AtReconstruction/AtPulseAnalyzer/AtPSATestFixture.h
@@ -1,0 +1,34 @@
+#include "AtDigiPar.h"
+
+#include <gtest/gtest.h>
+/**
+ * @brief Test fixture for AtPSA that creates a default AtDigiPar object to use.
+ * @ingroup Testing
+ */
+class AtPSATestFixture : public ::testing::Test {
+
+protected:
+   std::unique_ptr<AtDigiPar> fPar;
+
+   void SetUp() override
+   {
+      fPar = std::make_unique<AtDigiPar>("", "", "");
+      fPar->fEField = 70000;
+      fPar->fBField = 0.0;
+      fPar->fTBEntrance = 457;
+      fPar->fZPadPlane = 1000.0;
+      fPar->fEIonize = 42.70;
+      fPar->fFano = 0.24;
+      fPar->fCoefL = 0.0055;
+      fPar->fCoefT = 0.0038;
+      fPar->fGasPressure = 800;
+      fPar->fDensity = 0.175;
+      fPar->fDriftVelocity = 0.815;
+      fPar->fGain = 1000;
+      fPar->fSamplingRate = 3;
+      fPar->fGETGain = 1000;
+      fPar->fPeakingTime = 720;
+   }
+
+   void TearDown() override {}
+};

--- a/AtReconstruction/CMakeLists.txt
+++ b/AtReconstruction/CMakeLists.txt
@@ -154,6 +154,7 @@ endif()
 
 set(TEST_SRCS
   AtPulseAnalyzer/AtPSADeconvFitBaselineTest.cxx
+  AtPulseAnalyzer/AtPSATest.cxx
 )
 
 


### PR DESCRIPTION
Adds a [test fixture](https://github.com/google/googletest/blob/main/docs/primer.md#test-fixtures-using-the-same-data-configuration-for-multiple-tests-same-data-multiple-tests) to use with `AtPSA` classes. It instantiates an instance of `AtDigiPar` and fills it with default values used by the fission experiment. The values can be changed in the `SetUp` function of the test fixture. The fixture then initializes an instance of the class to fit. 

Each test created using this fixture will share a common setup (although each test will get its own copy, so the tests are independent).